### PR TITLE
Modify README.md to have the find(), findall() and key_exists() examples take a key argument, and not a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ False
 # it can take an argument called default which is taken as the default value if not found.
 >>> quick.get(['c', 'g', 5], default=0)
 0
->>> quick.find(['b'])
+>>> quick.find('b')
 12
->>> quick.findall(['b'])
+>>> quick.findall('b')
 [12, 2]
->>> quick.key_exists(['n'])
+>>> quick.key_exists('n')
 True
 
 >>> quick.data  # chokes out the object which is being manipulated


### PR DESCRIPTION
The examples given in the README for find(), findall() and key_exists() pass a list as the argument, while expected argument is just the key to be used. The required correction has been made in those examples.
